### PR TITLE
commonJS-wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 temp/
 dist/
 bower_components/
+/.idea/

--- a/.jshintrc
+++ b/.jshintrc
@@ -17,21 +17,9 @@
 	"devel": true,
 	"jquery": true,
 	"node": true,
-	"predef": {
-		"asyncTest": false,
-		"deepEqual": false,
-		"equal": false,
-		"expect": false,
-		"module": false,
-		"notDeepEqual": false,
-		"notEqual": false,
-		"notStrictEqual": false,
-		"ok": false,
-		"QUnit": false,
-		"raises": false,
-		"start": false,
-		"stop": false,
-		"strictEqual": false,
-		"test": false
-	}
+	"predef": [
+		"require",
+		"define",
+		"module"
+	]
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "fontfaceonload",
 	"version": "0.1.5",
 	"description": "A simple utility to execute a callback when a webfont loads.",
+	"main": "src/fontfaceonload.js",
 	"keywords": [
 		"grunt"
 	],

--- a/src/fontfaceonload.js
+++ b/src/fontfaceonload.js
@@ -1,5 +1,21 @@
-;(function( win, doc ) {
-	"use strict";
+(function (root, factory) {
+	'use strict';
+	if (typeof define === 'function' && define.amd) {
+		// AMD. Register as an anonymous module.
+		define([], factory);
+	} else if (typeof exports === 'object') {
+		// Node. Does not work with strict CommonJS, but
+		// only CommonJS-like environments that support module.exports,
+		// like Node.
+		module.exports = factory();
+	} else {
+		// Browser globals (root is window)
+		root.returnExports = factory();
+	}
+}(this, function () {
+	'use strict';
+	var doc = document,
+		win = window;
 
 	var TEST_STRING = 'AxmTYklsjo190QW',
 		SANS_SERIF_FONTS = 'sans-serif',
@@ -185,6 +201,5 @@
 		return instance;
 	};
 
-	// intentional global
-	win.FontFaceOnload = FontFaceOnload;
-})( this, this.document );
+	return FontFaceOnload;
+}));


### PR DESCRIPTION
Isuue https://github.com/zachleat/fontfaceonload/issues/18

Universal module exports wrapper added https://github.com/umdjs/umd/blob/master/returnExports.js#L40-L60

Now it can be used with any type of modules, not just [global](https://github.com/zachleat/fontfaceonload/blob/master/src/fontfaceonload.js#L189)!

And `main` field [added](https://github.com/yoyurec/fontfaceonload/blob/commonJS-wrapper/package.json#L5) to use with **browserify** (CommonJS require with simple node module name, not path to JS):

```
var fontfaceonload = require('fontfaceonload')
    fontfaceonload('.....', {
        .....
    });
```
