### PR TITLE
Replace use of innerHtml to prevent security issues in font-weight branch

### DIFF
--- a/src/fontfaceonload.js
+++ b/src/fontfaceonload.js
@@ -66,16 +66,17 @@
 			options = this.options,
 			ref = options.reference;
 
-		function getStyle( family ) {
-			var styleAttribute = document.createAttribute( 'style' );
-			
-			styleAttribute.value = style.concat( "font-family:" + family ).join( ";" );
+		function getStyle( family ) {      
+			var styleAttribute = style.concat( "font-family:" + family ).join( ";" );
+
 			return styleAttribute;
 		}
 
-
 		var sansSerifHtml = html.cloneNode( true ),
-        	serifHtml = html.cloneNode( true );
+			serifHtml = html.cloneNode( true );
+
+		sansSerifHtml.setAttribute( 'style', getStyle( SANS_SERIF_FONTS ) );
+		serifHtml.setAttribute( 'style', getStyle( SERIF_FONTS ) );
 
     	sansSerifHtml.styleAttributeNode( getStyle( SANS_SERIF_FONTS ) );
     	serifHtml.styleAttributeNode( getStyle( SERIF_FONTS ) );

--- a/src/fontfaceonload.js
+++ b/src/fontfaceonload.js
@@ -30,7 +30,8 @@
 			'font-variant:normal',
 			'white-space:nowrap'
 		],
-		html = '<div style="%s">' + TEST_STRING + '</div>';
+		html = document.createElement("div");
+		html.appendChild( document.createTextNode( TEST_STRING ) );
 
 	var FontFaceOnloadInstance = function() {
 		this.fontFamily = '';
@@ -65,20 +66,33 @@
 			options = this.options,
 			ref = options.reference;
 
-		var sansSerifHtml = html.replace( /\%s/, style.concat( "font-family:" + SANS_SERIF_FONTS ).join( ";" ) ),
-			serifHtml = html.replace( /\%s/, style.concat( "font-family:" + SERIF_FONTS ).join( ";" ) );
+		function getStyle( family ) {
+			var styleAttribute = document.createAttribute( 'style' );
+			
+			styleAttribute.value = style.concat( "font-family:" + family ).join( ";" );
+			return styleAttribute;
+		}
+
+
+		var sansSerifHtml = html.cloneNode( true ),
+        	serifHtml = html.cloneNode( true );
+
+    	sansSerifHtml.styleAttributeNode( getStyle( SANS_SERIF_FONTS ) );
+    	serifHtml.styleAttributeNode( getStyle( SERIF_FONTS ) );
 
 		if( !parent ) {
 			parent = that.parent = doc.createElement( "div" );
 		}
 
-		parent.innerHTML = sansSerifHtml + serifHtml;
+		parent.appendChild( sansSerifHtml );
+		parent.appendChild( serifHtml );
+
 		sansSerif = that.sansSerif = parent.firstChild;
 		serif = that.serif = sansSerif.nextSibling;
 
 		if( options.glyphs ) {
-			sansSerif.innerHTML += options.glyphs;
-			serif.innerHTML += options.glyphs;
+			sansSerif.appendChild( document.createTextNode( options.glyphs ) );
+			serif.appendChild( document.createTextNode( options.glyphs ) );
 		}
 
 		function hasNewDimensions( dims, el, tolerance ) {

--- a/src/fontfaceonload.js
+++ b/src/fontfaceonload.js
@@ -78,9 +78,6 @@
 		sansSerifHtml.setAttribute( 'style', getStyle( SANS_SERIF_FONTS ) );
 		serifHtml.setAttribute( 'style', getStyle( SERIF_FONTS ) );
 
-    	sansSerifHtml.styleAttributeNode( getStyle( SANS_SERIF_FONTS ) );
-    	serifHtml.styleAttributeNode( getStyle( SERIF_FONTS ) );
-
 		if( !parent ) {
 			parent = that.parent = doc.createElement( "div" );
 		}


### PR DESCRIPTION
Same as https://github.com/zachleat/fontfaceonload/pull/22 but for the font-weight branch.
