### PR TITLE
Makes it possible to add the font dynamically just before running fontfaceonload

### DIFF
--- a/src/fontfaceonload.js
+++ b/src/fontfaceonload.js
@@ -40,6 +40,7 @@
 		this.sansSerif = undefined;
 		this.parent = undefined;
 		this.options = {};
+		this.erorred = false;
 	};
 
 	FontFaceOnloadInstance.prototype.getMeasurements = function () {
@@ -121,6 +122,7 @@
 
 				options.success();
 			} else if( isTimeout() ) {
+				this.erorred = true;
 				options.error();
 			} else {
 				if( !appended && "requestAnimationFrame" in window ) {
@@ -148,16 +150,22 @@
 
 	FontFaceOnloadInstance.prototype.checkFontFaces = function( timeout ) {
 		var _t = this;
+		var found = false;
 		doc.fonts.forEach(function( font ) {
 			if( _t.cleanFamilyName( font.family ) === _t.cleanFamilyName( _t.fontFamily ) &&
 				_t.cleanWeight( font.weight ) === _t.cleanWeight( _t.options.weight ) &&
 				font.style === _t.options.style ) {
+				found = true;
 				font.load().then(function() {
 					_t.options.success();
 					win.clearTimeout( timeout );
 				});
 			}
 		});
+		// If the font has just been added to the document it may not have registered yet
+		if (found === false && this.erorred === false) {
+			window.setTimeout(this.checkFontFaces.bind(this, timeout ), _t.delay);
+		}
 	};
 
 	FontFaceOnloadInstance.prototype.init = function( fontFamily, options ) {
@@ -176,6 +184,7 @@
 		if( !options.glyphs && "fonts" in doc ) {
 			if( options.timeout ) {
 				timeout = win.setTimeout(function() {
+					this.erorred = true;
 					options.error();
 				}, options.timeout );
 			}


### PR DESCRIPTION
If the font has just been added to the document head it may not have registered yet when FontFaceOnloadInstance.prototype.checkFontFaces runs.

Solved by repeatedly checking until the timeout fires.